### PR TITLE
Make the "TO" field mandatory

### DIFF
--- a/lib/interfaces/Messages.ts
+++ b/lib/interfaces/Messages.ts
@@ -43,7 +43,7 @@ export type MailgunMessageData = MailgunMessageContent & {
      *
      * @example `Bob <bob@host.com>`. You can use commas to separate multiple recipients.
      */
-    to?: string | string[];
+    to: string | string[];
 
     /**
      * Same as `To` but for `carbon copy`


### PR DESCRIPTION
According to the official docs, the "TO" field is mandatory: https://documentation.mailgun.com/docs/mailgun/api-reference/openapi-final/tag/Messages/#tag/Messages/operation/POST-v3--domain-name--messages

However, in this type file, it is optional. If you try to send an email without the "TO" field you get an error that the "TO" field is mandatory.

Even though changing the docs will be true to the app, I believe that sending an email just with CC/BCC without the TO field should be allowed.